### PR TITLE
戦歴の画像URLを修正

### DIFF
--- a/app/server/achievements_server.go
+++ b/app/server/achievements_server.go
@@ -231,8 +231,11 @@ func achievementToResponse(ach *record.Achievement, includePrivate bool, cfg *co
 		Award:         ach.Award,
 		Url:           ach.URL,
 		Description:   ach.Description,
-		ImageUrl:      cfg.MinioPublicURL + "/" + cfg.MinioBucketName + "/" + ach.ImageFilename.String,
 		HappenedAt:    timeToResponse(ach.HappenedAt),
+	}
+
+	if ach.ImageFilename.Valid {
+		resp.ImageUrl = cfg.MinioPublicURL + "/" + cfg.MinioBucketName + "/" + ach.ImageFilename.String
 	}
 
 	members := make([]*record.User, 0)


### PR DESCRIPTION
戦歴の画像が設定されていないときによくわからないurlが返ってきてた